### PR TITLE
Add :context-handler option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject ring-server "0.2.5"
+(defproject ring-server "0.2.6-SNAPSHOT"
   :description "Library for running Ring web servers"
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.clojure/core.incubator "0.1.0"]
-                 [ring "1.1.4"]
+                 [ring "1.2.0-SNAPSHOT"]
                  [ring-refresh "0.1.1"]]
   :plugins [[codox "0.6.1"]]
   :profiles {:dev {:dependencies [[clj-http "0.4.1"]]}})

--- a/src/ring/server/standalone.clj
+++ b/src/ring/server/standalone.clj
@@ -5,6 +5,7 @@
         ring.middleware.stacktrace
         ring.middleware.reload
         ring.middleware.refresh
+        ring.middleware.context
         [clojure.java.browse :only (browse-url)]))
 
 (defn- try-port
@@ -65,11 +66,17 @@
     (wrap-refresh handler)
     handler))
 
+(defn- add-context [handler options]
+  (if (:context-handler options)
+    (wrap-context handler)
+    handler))
+
 (defn- add-middleware [handler options]
   (-> handler
       (add-auto-refresh options)
       (add-auto-reload options)
-      (add-stacktraces options)))
+      (add-stacktraces options)
+      (add-context options)))
 
 (defn serve
   "Start a web server to run a handler. Takes the following options:


### PR DESCRIPTION
This option wraps the handler with ring.middleware.context so that it
behaves like it is inside a ServletContext. This means it splits :uri
and fills in the :context and :path-info fields in request. This option
can be used so that 'lein ring server' behaves like a container.

This pull request is dependent on ring-clojure/ring#27.
