### PR TITLE
Add :browser-uri option (was :status-path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ The following options are supported:
   True if you want a browser to be opened to the server. Defaults to
   true in development mode, false in production mode.
 
+* `:browser-uri` -
+  A path to append to the target URL if opening a browser (default 
+  none). The full URI will be constructed like:
+  `http://{host}:{port}{browser-uri}`
+
 * `:stacktrace?` -
   True if you want a stacktrace to be displayed in the browser when
   an exception is raised. Default to true in development, false in

--- a/src/ring/server/options.clj
+++ b/src/ring/server/options.clj
@@ -1,7 +1,8 @@
 (ns ring.server.options
   "Functions to retrieve options and settings with sensible defaults"
   (:use ring.util.environment
-        [clojure.core.incubator :only (-?>)]))
+        [clojure.core.incubator :only (-?>)])
+  (:require [clojure.string :as str]))
 
 (def dev-env?
   (not (*env* "LEIN_NO_DEV")))
@@ -19,6 +20,12 @@
   a browser is opened unless the LEIN_NO_DEV environment variable is set."
   [options]
   (:open-browser? options dev-env?))
+
+(defn browser-uri
+  "The path to browse to when opening a browser"
+  [options]
+  (-> (str "/" (:browser-uri options))
+      (str/replace #"^/+" "/")))
 
 (defn auto-reload?
   "True if the source files should be automatically reloaded."

--- a/src/ring/server/standalone.clj
+++ b/src/ring/server/standalone.clj
@@ -34,9 +34,9 @@
       (.getHost)
       (or "localhost")))
 
-(defn- open-browser-to [server]
+(defn- open-browser-to [server options]
   (browse-url
-   (str "http://" (server-host server) ":" (server-port server))))
+   (str "http://" (server-host server) ":" (server-port server) (browser-uri options))))
 
 (defmacro ^{:private true} in-thread
   "Execute the body in a new thread and return the Thread object."
@@ -78,6 +78,7 @@
     :init          - a function to run before the server starts
     :destroy       - a function to run after the server stops
     :open-browser? - if true, open a web browser after the server starts
+    :browser-uri   - the path to browse to when opening a browser
     :stacktraces?  - if true, display stacktraces when an exception is thrown
     :auto-reload?  - if true, automatically reload source files
     :auto-refresh? - if true, automatically refresh browser when source changes
@@ -94,12 +95,12 @@
          (addShutdownHook (Thread. destroy))))
     (try-port (port options)
       (fn [port]
-        (let [options (merge {:port port} options) 
+        (let [options (merge {:port port} options)
               server  (run-jetty handler options)
               thread  (add-destroy-hook server destroy)]
           (println "Started server on port" (server-port server))
           (if (open-browser? options)
-            (open-browser-to server))
+            (open-browser-to server options))
           (if join?
             (.join thread))
           server)))))


### PR DESCRIPTION
New option to append a path to the target URL when opening a browser.
