### PR TITLE
:reload-paths option to configure reload directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The following options are supported:
   True if you want your source files to be automatically reloaded
   when they are modified. Defaults to true in development, false in
   production.
+  
+* `:reload-paths` -
+  A seq of source paths to reload. Defaults to [\"src\"]. 
+  Only relevant if :auto-reload? is true.
 
 * `:auto-refresh?` -
   True if you want your browser to automatically refresh when source

--- a/src/ring/server/options.clj
+++ b/src/ring/server/options.clj
@@ -36,3 +36,7 @@
   "True if stacktraces should be shown for exceptions raised by the handler."
   [options]
   (:stacktraces? options dev-env?))
+
+(defn reload-paths 
+  [options]
+  (:reload-paths options ["src"]))

--- a/src/ring/server/standalone.clj
+++ b/src/ring/server/standalone.clj
@@ -57,7 +57,7 @@
 
 (defn- add-auto-reload [handler options]
   (if (auto-reload? options)
-    (wrap-reload handler {:dirs (:reload-paths options)})
+    (wrap-reload handler {:dirs (reload-paths options)})
     handler))
 
 (defn- add-auto-refresh [handler options]


### PR DESCRIPTION
Pull request replaces https://github.com/weavejester/ring-server/pull/8

added :reload-paths to options to specify which source paths to
use for reload if auto-reload? is true

Preparation for change to lein-ring
