### PR TITLE
Make the add-middleware function public

### DIFF
--- a/src/ring/server/standalone.clj
+++ b/src/ring/server/standalone.clj
@@ -65,7 +65,7 @@
     (wrap-refresh handler)
     handler))
 
-(defn- add-middleware [handler options]
+(defn add-middleware [handler options]
   (-> handler
       (add-auto-refresh options)
       (add-auto-reload options)


### PR DESCRIPTION
I'd love for `immutant.web/start` to accept the same handy dev-mode 
options provided by ring-server, but I'd rather not rewrite the code.
If this function was exposed, I'd be set! :) 
