### PR TITLE
Fix typo (change :stacktrace? to :stacktraces?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following options are supported:
   none). The full URI will be constructed like:
   `http://{host}:{port}{browser-uri}`
 
-* `:stacktrace?` -
+* `:stacktraces?` -
   True if you want a stacktrace to be displayed in the browser when
   an exception is raised. Default to true in development, false in
   production.


### PR DESCRIPTION
In code it checks for key `:stacktraces?` instead of `:stacktrace?`
https://github.com/weavejester/ring-server/blob/master/src/ring/server/options.clj#L38
