### PR TITLE
Able to specify dirs that will trigger browser refresh

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-server "0.3.1"
+(defproject ring-server "0.3.2"
   :description "Library for running Ring web servers"
   :url "https://github.com/weavejester/ring-server"
   :license {:name "Eclipse Public License"

--- a/src/ring/server/options.clj
+++ b/src/ring/server/options.clj
@@ -38,5 +38,11 @@
   (:stacktraces? options dev-env?))
 
 (defn reload-paths 
+  "Specify the paths for source code that should get reloaded."
   [options]
   (:reload-paths options ["src"]))
+
+(defn refresh-paths 
+  "Specify the paths that should trigger browser refreshes."
+  [options]
+  (:refresh-paths options ["src" "resources"]))

--- a/src/ring/server/standalone.clj
+++ b/src/ring/server/standalone.clj
@@ -62,7 +62,7 @@
 
 (defn- add-auto-refresh [handler options]
   (if (:auto-refresh? options)
-    (wrap-refresh handler)
+    (wrap-refresh handler (refresh-paths options))
     handler))
 
 (defn- add-middleware [handler options]
@@ -81,8 +81,9 @@
     :browser-uri   - the path to browse to when opening a browser
     :stacktraces?  - if true, display stacktraces when an exception is thrown
     :auto-reload?  - if true, automatically reload source files
-    :reload-paths  - seq of src-paths to reload on change - defaults to [\"src\"]    
+    :reload-paths  - seq of src-paths to reload on change - defaults to [\"src\"]
     :auto-refresh? - if true, automatically refresh browser when source changes
+    :refresh-paths - seq of src-paths that will trigger browser to refresh - defaults to [\"src\" \"resources\"]. only relevant if :auto-refresh? equals true
 
   If join? is false, a Server object is returned."
   {:arglists '([handler] [handler options])}


### PR DESCRIPTION
The auto-refresh? feature is great. When playing around with clojurescript, it's nice to be able to control which directories trigger auto refresh. For example, it can be annoying when the browser refreshes when saving cljs files under src/cljs because it will clear any work in a browser repl session.

So, here's a small addition to allow specifying :refresh-path. 

Dave
