### PR TITLE
Support custom stacktrace middleware

### DIFF
--- a/src/ring/server/leiningen.clj
+++ b/src/ring/server/leiningen.clj
@@ -17,4 +17,5 @@
     (:ring project)
     (-> project :ring :adapter)
     {:init    (load-var (-> project :ring :init))
-     :destroy (load-var (-> project :ring :destroy))})))
+     :destroy (load-var (-> project :ring :destroy))
+     :stacktrace-middleware (load-var (-> project :ring :stacktrace-middleware))})))

--- a/src/ring/server/standalone.clj
+++ b/src/ring/server/standalone.clj
@@ -52,7 +52,8 @@
 
 (defn- add-stacktraces [handler options]
   (if (stacktraces? options)
-    (wrap-stacktrace handler)
+    ((or (:stacktrace-middleware options)
+         wrap-stacktrace) handler)
     handler))
 
 (defn- add-auto-reload [handler options]
@@ -73,16 +74,17 @@
 
 (defn serve
   "Start a web server to run a handler. Takes the following options:
-    :port          - the port to run the server on
-    :join?         - if true, wait for the server to stop
-    :init          - a function to run before the server starts
-    :destroy       - a function to run after the server stops
-    :open-browser? - if true, open a web browser after the server starts
-    :browser-uri   - the path to browse to when opening a browser
-    :stacktraces?  - if true, display stacktraces when an exception is thrown
-    :auto-reload?  - if true, automatically reload source files
-    :reload-paths  - seq of src-paths to reload on change - defaults to [\"src\"]    
-    :auto-refresh? - if true, automatically refresh browser when source changes
+    :port                  - the port to run the server on
+    :join?                 - if true, wait for the server to stop
+    :init                  - a function to run before the server starts
+    :destroy               - a function to run after the server stops
+    :open-browser?         - if true, open a web browser after the server starts
+    :browser-uri           - the path to browse to when opening a browser
+    :stacktraces?          - if true, display stacktraces when an exception is thrown
+    :stacktrace-middleware - a middleware that handles stacktraces
+    :auto-reload?          - if true, automatically reload source files
+    :reload-paths          - seq of src-paths to reload on change - defaults to [\"src\"]
+    :auto-refresh?         - if true, automatically refresh browser when source changes
 
   If join? is false, a Server object is returned."
   {:arglists '([handler] [handler options])}

--- a/test/ring/server/test/standalone.clj
+++ b/test/ring/server/test/standalone.clj
@@ -1,4 +1,4 @@
-(ns ring.server.test.standalone 
+(ns ring.server.test.standalone
   (:use clojure.test
         ring.server.standalone
         ring.server.test.utils
@@ -25,7 +25,7 @@
 
   (testing "PORT environment variable"
     (with-env {"PORT" "4563"}
-      (with-server (test-server) 
+      (with-server (test-server)
         (is-server-running-on-port 4563))))
 
   (testing ":port option"
@@ -48,4 +48,15 @@
     (with-server (test-server {:handler exception-handler})
       (let [body (:body (http-get 3000 ""))]
         (is (re-find #"java\.lang\.Exception" body))
-        (is (re-find #"testing" body))))))
+        (is (re-find #"testing" body)))))
+
+  (testing "custom stacktrace middleware"
+    (let [middleware (fn [handler]
+                       (fn [req]
+                         (try (handler req)
+                              (catch Exception e
+                                  {:body "Hello"}))))]
+      (with-server (test-server {:handler exception-handler
+                                 :stacktrace-middleware middleware})
+        (is (= (:body (http-get 3000 ""))
+               "Hello"))))))


### PR DESCRIPTION
Adds new option `:stacktrace-middleware`, a middleware function that handles exceptions.

See #20
