### PR TITLE
Provide an option to re-resolve handler per request.

### DIFF
--- a/src/ring/server/leiningen.clj
+++ b/src/ring/server/leiningen.clj
@@ -7,11 +7,17 @@
     (require (-> sym namespace symbol))
     (find-var sym)))
 
+(defn get-handler [project]
+  (let [handler-sym (-> project :ring :handler)]
+    (if (-> project :ring :re-resolve)
+      (fn [r] ((load-var handler-sym) r))
+      (load-var handler-sym))))
+
 (defn serve
   "Start a server from a Leiningen project map."
   [project]
   (standalone/serve
-   (load-var (-> project :ring :handler))
+   (get-handler project)
    (merge
     {:join? true}
     (:ring project)


### PR DESCRIPTION
Stuart Sierra's tools.namespace library reloads namespaces by creating
entirely new Var objects. For developers using it in their workflow, a
server which holds a reference to a Var object won't successfully pick
up changes. Provide an option to resolve the var on every request.