### PR TITLE
Wrapped ring adapter configurator in load-var

### DIFF
--- a/src/ring/server/leiningen.clj
+++ b/src/ring/server/leiningen.clj
@@ -21,7 +21,9 @@
    (merge
     {:join? true}
     (:ring project)
-    (-> project :ring :adapter)
+    (merge
+     (-> project :ring :adapter)
+     {:configurator (load-var (-> project :ring :adapter :configurator))})
     {:init    (load-var (-> project :ring :init))
      :destroy (load-var (-> project :ring :destroy))
      :stacktrace-middleware (load-var (-> project :ring :stacktrace-middleware))})))


### PR DESCRIPTION
I see users (and myself) have an issue with passing adapter configurator. Can we wrap it in `load-var` call the same way as `handler`, `init` and other function references?

# References

https://github.com/weavejester/ring-server/issues/14
[clojure/ring/jetty: I am using > lein ring server. How do I configure the jetty instance that gets instantiated?](https://stackoverflow.com/questions/10289617/clojure-ring-jetty-i-am-using-lein-ring-server-how-do-i-configure-the-jetty)
[lein-ring - cannot call configurator function on ring-jetty-adapter - "No reader function for tag object" error](https://stackoverflow.com/questions/33176633/lein-ring-cannot-call-configurator-function-on-ring-jetty-adapter-no-reader)